### PR TITLE
Fix broken overrides for jsonschema

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -66,7 +66,7 @@ in skipOverrides {
 
   "jsonschema" = self: old: {
     patchPhase = ''
-      sed -i -e 's|setup_requires=\["vcversioner"\],||' setup.py
+      sed -i -e 's|setup_requires=\["vcversioner[><=0-9\.]*"\],||' setup.py
     '';
   };
 


### PR DESCRIPTION
The regular expression that was supposed to match vcversioner in the setup.py of jsonschema was broken, since upstream added version bounds.