### PR TITLE
Get travis CI working for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-branches:
-  only:
-    - master
-
 language: nix
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,32 +32,10 @@ script:
 - nix copy --to file://./nars/ ./result-$PKGS_SET;
 
 before_install:
-- git branch
-- echo $TRAVIS_BRANCH
-- sudo mkdir -p /etc/nix
-- echo 'binary-caches = https://cache.nixos.org/ https://travis.garbas.si/nixpkgs-python/' | sudo tee -a /etc/nix/nix.conf > /dev/null
-- echo 'require-sigs = false' | sudo tee -a /etc/nix/nix.conf > /dev/null
-- openssl aes-256-cbc -K $encrypted_1ae048d151c2_key -iv $encrypted_1ae048d151c2_iv -in deploy_rsa.enc -out deploy_rsa -d
-- eval "$(ssh-agent -s)"
-- chmod 600 $TRAVIS_BUILD_DIR/deploy_rsa
-- ssh-add $TRAVIS_BUILD_DIR/deploy_rsa
+- source .travis/before_install
 
 install:
   - echo 'garbas.si ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPNIqf3Qgnwr/CMslsEK7qIFHOcWWdxvzJIZwBQPjulZ' >> $HOME/.ssh/known_hosts
 
 after_success:
-- rsync -avh --ignore-existing /tmp/pypi2nix/cache/wheel/*.whl travis@garbas.si:/var/travis/wheels_cache/
-- rsync -avh --ignore-existing $TRAVIS_BUILD_DIR/nars/ travis@garbas.si:/var/travis/nixpkgs-python/
-- if [[ -n `git diff --exit-code` ]]; then
-    git config user.name 'travis';
-    git config user.email 'travis@garbas.si';
-    git status;
-    git --no-pager diff $PKGS_SET;
-    git stash;
-    git checkout -b result-$TRAVIS_BRANCH origin/$TRAVIS_BRANCH;
-    git pull;
-    git stash apply;
-    git add $PKGS_SET;
-    git commit -m "Travis update for $PKGS_SET [ci skip]";
-    git push git@github.com:garbas/nixpkgs-python.git HEAD:$TRAVIS_BRANCH;
-  fi
+- source .travis/after_success

--- a/.travis/after_success
+++ b/.travis/after_success
@@ -1,8 +1,8 @@
 # -*- mode: sh -*-
 
-if [ $TRAVIS_PULL_REQUEST = "false" -a
-     $TRAVIS_BRANCH = "master" -a
-     $TRAVIS_REPO_SLUG = "garbas/nixpkgs-python"
+if [ $TRAVIS_PULL_REQUEST = "false" -a \
+     $TRAVIS_BRANCH = "master" -a \
+     $TRAVIS_REPO_SLUG = "garbas/nixpkgs-python" \
    ]; then
     rsync -avh --ignore-existing /tmp/pypi2nix/cache/wheel/*.whl travis@garbas.si:/var/travis/wheels_cache/
     rsync -avh --ignore-existing $TRAVIS_BUILD_DIR/nars/ travis@garbas.si:/var/travis/nixpkgs-python/

--- a/.travis/after_success
+++ b/.travis/after_success
@@ -1,17 +1,19 @@
 # -*- mode: sh -*-
 
-rsync -avh --ignore-existing /tmp/pypi2nix/cache/wheel/*.whl travis@garbas.si:/var/travis/wheels_cache/
-rsync -avh --ignore-existing $TRAVIS_BUILD_DIR/nars/ travis@garbas.si:/var/travis/nixpkgs-python/
-if [[ -n `git diff --exit-code` ]]; then
-    git config user.name 'travis';
-    git config user.email 'travis@garbas.si';
-    git status;
-    git --no-pager diff $PKGS_SET;
-    git stash;
-    git checkout -b result-$TRAVIS_BRANCH origin/$TRAVIS_BRANCH;
-    git pull;
-    git stash apply;
-    git add $PKGS_SET;
-    git commit -m "Travis update for $PKGS_SET [ci skip]";
-    git push git@github.com:garbas/nixpkgs-python.git HEAD:$TRAVIS_BRANCH;
+if [ $TARVIS_PULL_REQUEST = "false" ]; then
+    rsync -avh --ignore-existing /tmp/pypi2nix/cache/wheel/*.whl travis@garbas.si:/var/travis/wheels_cache/
+    rsync -avh --ignore-existing $TRAVIS_BUILD_DIR/nars/ travis@garbas.si:/var/travis/nixpkgs-python/
+    if [[ -n `git diff --exit-code` ]]; then
+	git config user.name 'travis';
+	git config user.email 'travis@garbas.si';
+	git status;
+	git --no-pager diff $PKGS_SET;
+	git stash;
+	git checkout -b result-$TRAVIS_BRANCH origin/$TRAVIS_BRANCH;
+	git pull;
+	git stash apply;
+	git add $PKGS_SET;
+	git commit -m "Travis update for $PKGS_SET [ci skip]";
+	git push git@github.com:garbas/nixpkgs-python.git HEAD:$TRAVIS_BRANCH;
+    fi
 fi

--- a/.travis/after_success
+++ b/.travis/after_success
@@ -1,0 +1,17 @@
+# -*- mode: sh -*-
+
+rsync -avh --ignore-existing /tmp/pypi2nix/cache/wheel/*.whl travis@garbas.si:/var/travis/wheels_cache/
+rsync -avh --ignore-existing $TRAVIS_BUILD_DIR/nars/ travis@garbas.si:/var/travis/nixpkgs-python/
+if [[ -n `git diff --exit-code` ]]; then
+    git config user.name 'travis';
+    git config user.email 'travis@garbas.si';
+    git status;
+    git --no-pager diff $PKGS_SET;
+    git stash;
+    git checkout -b result-$TRAVIS_BRANCH origin/$TRAVIS_BRANCH;
+    git pull;
+    git stash apply;
+    git add $PKGS_SET;
+    git commit -m "Travis update for $PKGS_SET [ci skip]";
+    git push git@github.com:garbas/nixpkgs-python.git HEAD:$TRAVIS_BRANCH;
+fi

--- a/.travis/after_success
+++ b/.travis/after_success
@@ -1,6 +1,9 @@
 # -*- mode: sh -*-
 
-if [ $TARVIS_PULL_REQUEST = "false" ]; then
+if [ $TRAVIS_PULL_REQUEST = "false" -a
+     $TRAVIS_BRANCH = "master" -a
+     $TRAVIS_REPO_SLUG = "garbas/nixpkgs-python"
+   ]; then
     rsync -avh --ignore-existing /tmp/pypi2nix/cache/wheel/*.whl travis@garbas.si:/var/travis/wheels_cache/
     rsync -avh --ignore-existing $TRAVIS_BUILD_DIR/nars/ travis@garbas.si:/var/travis/nixpkgs-python/
     if [[ -n `git diff --exit-code` ]]; then

--- a/.travis/before_install
+++ b/.travis/before_install
@@ -1,11 +1,15 @@
 # -*- mode: sh -*-
 
+set -x
+
 git branch
 echo $TRAVIS_BRANCH
 sudo mkdir -p /etc/nix
 echo 'binary-caches = https://cache.nixos.org/ https://travis.garbas.si/nixpkgs-python/' | sudo tee -a /etc/nix/nix.conf > /dev/null
 echo 'require-sigs = false' | sudo tee -a /etc/nix/nix.conf > /dev/null
-openssl aes-256-cbc -K $encrypted_1ae048d151c2_key -iv $encrypted_1ae048d151c2_iv -in deploy_rsa.enc -out deploy_rsa -d
-eval "$(ssh-agent -s)"
-chmod 600 $TRAVIS_BUILD_DIR/deploy_rsa
-ssh-add $TRAVIS_BUILD_DIR/deploy_rsa
+if [ $TRAVIS_PULL_REQUEST = "false" ]; then
+    openssl aes-256-cbc -K $encrypted_1ae048d151c2_key -iv $encrypted_1ae048d151c2_iv -in deploy_rsa.enc -out deploy_rsa -d
+    eval "$(ssh-agent -s)"
+    chmod 600 $TRAVIS_BUILD_DIR/deploy_rsa
+    ssh-add $TRAVIS_BUILD_DIR/deploy_rsa
+fi

--- a/.travis/before_install
+++ b/.travis/before_install
@@ -1,13 +1,14 @@
 # -*- mode: sh -*-
 
-set -x
-
 git branch
 echo $TRAVIS_BRANCH
 sudo mkdir -p /etc/nix
 echo 'binary-caches = https://cache.nixos.org/ https://travis.garbas.si/nixpkgs-python/' | sudo tee -a /etc/nix/nix.conf > /dev/null
 echo 'require-sigs = false' | sudo tee -a /etc/nix/nix.conf > /dev/null
-if [ $TRAVIS_PULL_REQUEST = "false" ]; then
+if [ $TRAVIS_PULL_REQUEST = "false" -a
+     $TRAVIS_BRANCH = "master" -a
+     $TRAVIS_REPO_SLUG = "garbas/nixpkgs-python"
+   ]; then
     openssl aes-256-cbc -K $encrypted_1ae048d151c2_key -iv $encrypted_1ae048d151c2_iv -in deploy_rsa.enc -out deploy_rsa -d
     eval "$(ssh-agent -s)"
     chmod 600 $TRAVIS_BUILD_DIR/deploy_rsa

--- a/.travis/before_install
+++ b/.travis/before_install
@@ -1,0 +1,11 @@
+# -*- mode: sh -*-
+
+git branch
+echo $TRAVIS_BRANCH
+sudo mkdir -p /etc/nix
+echo 'binary-caches = https://cache.nixos.org/ https://travis.garbas.si/nixpkgs-python/' | sudo tee -a /etc/nix/nix.conf > /dev/null
+echo 'require-sigs = false' | sudo tee -a /etc/nix/nix.conf > /dev/null
+openssl aes-256-cbc -K $encrypted_1ae048d151c2_key -iv $encrypted_1ae048d151c2_iv -in deploy_rsa.enc -out deploy_rsa -d
+eval "$(ssh-agent -s)"
+chmod 600 $TRAVIS_BUILD_DIR/deploy_rsa
+ssh-add $TRAVIS_BUILD_DIR/deploy_rsa

--- a/.travis/before_install
+++ b/.travis/before_install
@@ -5,9 +5,9 @@ echo $TRAVIS_BRANCH
 sudo mkdir -p /etc/nix
 echo 'binary-caches = https://cache.nixos.org/ https://travis.garbas.si/nixpkgs-python/' | sudo tee -a /etc/nix/nix.conf > /dev/null
 echo 'require-sigs = false' | sudo tee -a /etc/nix/nix.conf > /dev/null
-if [ $TRAVIS_PULL_REQUEST = "false" -a
-     $TRAVIS_BRANCH = "master" -a
-     $TRAVIS_REPO_SLUG = "garbas/nixpkgs-python"
+if [ $TRAVIS_PULL_REQUEST = "false" -a \
+     $TRAVIS_BRANCH = "master" -a \
+     $TRAVIS_REPO_SLUG = "garbas/nixpkgs-python" \
    ]; then
     openssl aes-256-cbc -K $encrypted_1ae048d151c2_key -iv $encrypted_1ae048d151c2_iv -in deploy_rsa.enc -out deploy_rsa -d
     eval "$(ssh-agent -s)"


### PR DESCRIPTION
Hi, it would be really nice if travis-ci.org would test contributer submitted PRs.  This would give us the ability to see they broke something accidentally.  The only thing holding us back from this right now is the fact that we need RSA keys provided by @garbas. These key are not accessible for other users.  In this patch I check if we build something from "garbas/nixpkgs-python" master branch and if not, we skip all the RSA stuff and don't push build results garbas binary cache.